### PR TITLE
independent remapping of reads

### DIFF
--- a/mapping/find_intersecting_snps.py
+++ b/mapping/find_intersecting_snps.py
@@ -522,27 +522,23 @@ def generate_reads(read_seq, read_pos, ref_alleles, alt_alleles):
     of alleles (i.e. 2^n combinations where n is the number of snps overlapping
     the reads)
     """
-    # use a deque so that we can use the same object in memory when we get to
-    # the nested while loop (rather than recreating a new list every time)
+    # use a deque so that we can use the same object in memory after
+    # the nested for loop (rather than recreating a new list every time)
     reads = deque([read_seq])
-    i = 0
     # iterate through all snp locations
-    while i != len(read_pos):
+    for i in range(len(read_pos)):
         idx = read_pos[i]-1
-        j = len(reads)
         # for each read we've already created...
-        while j > 0:
+        for j in range(len(reads)):
             read = reads.popleft()
-            # create a new version of this read with both reference...
+            # create a new version of this read with both reference
+            # and alternative versions of the allele at this index
             reads.append(
               read[:idx] + ref_alleles[i].decode("utf-8") + read[idx+1:]
             )
-            # and alternative versions of the allele at this index
             reads.append(
               read[:idx] + alt_alleles[i].decode("utf-8") + read[idx+1:]
             )
-            j -= 1
-        i += 1
     return set(reads)
 
 
@@ -757,8 +753,8 @@ def read_pair_combos(new_reads, max_seqs, snp_idx, snp_read_pos):
     returns False before more than max_seqs pairs are created
     """
     unique_pairs = set()
-    # get a list of the snps that are in both reads
-    shared_snp_idxs = list(set(snp_idx[0]) & set(snp_idx[1]))
+    # get the indices of the snps that are in both reads
+    shared_snp_idxs = set(snp_idx[0]).intersection(snp_idx[1])
     # get a grouping of the reads
     for i in range(len(new_reads)):
         new_reads[i] = group_reads_by_snps(

--- a/mapping/find_intersecting_snps.py
+++ b/mapping/find_intersecting_snps.py
@@ -718,6 +718,22 @@ def filter_reads(files, max_seqs=MAX_SEQS_DEFAULT, max_snps=MAX_SNPS_DEFAULT,
 
 def read_pair_combinations(new_reads, max_seqs, snp_idx, snp_pos):
     """collect all unique combinations of read pairs"""
+
+    # get a list of the snps that are in both reads
+    shared_snp_idxs = list(set(snp_idx[0]) & set(snp_idx[1]))
+    # find the index of each snp_index in snp_idx
+    idx_idxs = (
+        np.array([snp_idx[0].index(idx) for idx in shared_snp_idxs], dtype=int),
+        np.array([snp_idx[1].index(idx) for idx in shared_snp_idxs], dtype=int)
+    )
+    # use idx_idxs to get the read positions of each snp that appears in
+    # both reads
+    snp_pos = np.column_stack((
+        np.array(snp_pos[0], dtype=int)[idx_idxs[0]],
+        np.array(snp_pos[1], dtype=int)[idx_idxs[1]],
+    ))
+    print(snp_pos)
+
     unique_pairs = set([])
     n_unique_pairs = 0
     for new_read1 in new_reads[0]:
@@ -786,6 +802,8 @@ def process_paired_read(read1, read2, read_stats, files,
             new_reads.append(read_seqs)
         else:
             # no SNPs or indels overlap this read
+            pair_snp_idx.append([])
+            pair_snp_pos.append([])
             new_reads.append([])
 
     if len(new_reads[0]) == 0 and len(new_reads[1]) == 0:

--- a/mapping/find_intersecting_snps.py
+++ b/mapping/find_intersecting_snps.py
@@ -844,9 +844,7 @@ def process_paired_read(read1, read2, read_stats, files,
             return
 
         # remove original read pair, if present
-        orig_pair = (read1.query_sequence, read2.query_sequence)
-        if orig_pair in unique_pairs:
-            unique_pairs.remove(orig_pair)
+        unique_pairs.discard((read1.query_sequence, read2.query_sequence))
             
         # write read pair to fastqs for remapping
         write_pair_fastq(files.fastq1, files.fastq2, read1, read2,

--- a/mapping/test_find_intersecting_snps.py
+++ b/mapping/test_find_intersecting_snps.py
@@ -3297,14 +3297,14 @@ class TestOverlappingPEReads:
         #
         with gzip.open(test_data.fastq1_remap_filename, "rt") as f:
             lines = [x.strip() for x in f.readlines()]
-        assert len(lines) == 8
+        assert(len(lines) == 8)
 
         l = list(test_data.read1_seqs[0])
         # last base of first read should be changed from A to C
         l[13] = 'C'
         new_seq = "".join(l)
-        assert lines[1] == new_seq
-        assert lines[3] == test_data.read1_quals[0]
+        assert(lines[1] == new_seq)
+        assert(lines[3] == test_data.read1_quals[0])
 
         l = list(test_data.read1_seqs[1])
         # second to last base of second read should be changed from T to G
@@ -3318,21 +3318,21 @@ class TestOverlappingPEReads:
         #
         with gzip.open(test_data.fastq2_remap_filename, "rt") as f:
             lines = [x.strip() for x in f.readlines()]
-        assert len(lines) == 8
+        assert(len(lines) == 8)
 
-        l = list(test_data.read1_seqs[0])
+        l = list(test_data.read2_seqs[0])
         # second to last base of first read should be changed from T to G (since G is the complement of C)
         l[12] = 'G'
         new_seq = "".join(l)
-        assert lines[1] == new_seq
-        assert lines[3] == test_data.read1_quals[0]
+        assert(lines[1] == new_seq)
+        assert(lines[3] == test_data.read2_quals[0])
 
-        l = list(test_data.read1_seqs[1])
+        l = list(test_data.read2_seqs[1])
         # second to last base of second read should be changed from A to C (since C is the complement of G)
         l[12] = 'C'
         new_seq = "".join(l)
         assert(lines[5] == new_seq)
-        assert(lines[7] == test_data.read1_quals[1])
+        assert(lines[7] == test_data.read2_quals[1])
 
         #
         # Verify to.remap bam is the same as the input bam file.

--- a/mapping/test_find_intersecting_snps.py
+++ b/mapping/test_find_intersecting_snps.py
@@ -1336,7 +1336,7 @@ class TestPairedEnd:
         # read2[0]                      AACACAACAAAGAA
         # read2[1]                      AACACAACAAAGAA
         # POS           123456789012345678901234567890
-        
+
         snp_list = [['test_chrom', 18, "A", "C"]]
         
         test_data = Data(genome_seqs=genome_seq,
@@ -2603,7 +2603,7 @@ class TestHaplotypesSingleEnd:
         assert len(lines) == 1
         assert lines[0] == ''
 
-        # test_data.cleanup()
+        test_data.cleanup()
 
 
 
@@ -2774,7 +2774,7 @@ class TestHaplotypesPairedEnd:
         assert lines2[1] == test_data.read2_seqs[0]
         assert lines2[3] == test_data.read2_quals[0]
 
-        # test_data.cleanup()
+        test_data.cleanup()
 
 
 class TestFiltering:

--- a/mapping/test_find_intersecting_snps.py
+++ b/mapping/test_find_intersecting_snps.py
@@ -3254,8 +3254,8 @@ class TestOverlappingPEReads:
 
         read1_seqs = ["AACGAAAAGGAGAA",
                       "TTTATTTTTTATTT"]
-        read2_seqs = ["TTTTAAATTTTTTT",
-                      "ACAACACAAAAAAA"]
+        read2_seqs = ["TTTTAAATTTTTTT",  # AAAAAAATTTAAAA
+                      "ACAACACAAAAAAA"]  # TTTTTTTGTGTTGT
 
         read1_quals = ["B" * len(read1_seqs[0]),
                        "C" * len(read1_seqs[1])]
@@ -3264,12 +3264,12 @@ class TestOverlappingPEReads:
 
         # POS           123456789012345678901234567890
         # read1[0]          AACGAAAAGGAGAA
-        # read2[0]                      TTTTAAATTTTTTT
+        # read2[0]                      AAAAAAATTTAAAA
         # SNP                            ^
         genome_seq =  ["AAAAAACGAAAAGGAGAAAAAAATTTAAAA\n"
                        "TTTATTTTTTATTTTTTTGTGTTGTTTCTT"]
         # read1[1]      TTTATTTTTTATTT
-        # read2[1]                 ACAACACAAAAAAA
+        # read2[1]                 TTTTTTTGTGTTGT
         # SNP                       ^
         # POS           123456789012345678901234567890
 
@@ -3359,8 +3359,8 @@ class TestOverlappingPEReads:
 
         read1_seqs = ["AACGAAAAGGAGAA",
                       "TTTATTTTTTATTT"]
-        read2_seqs = ["TTTTAAATTTTTTT",
-                      "ACAACACAAAAAAA"]
+        read2_seqs = ["TTTTAAATTTTTTT",  # AAAAAAATTTAAAA
+                      "ACAACACAAAAAAA"]  # TTTTTTTGTGTTGT
 
         read1_quals = ["B" * len(read1_seqs[0]),
                        "C" * len(read1_seqs[1])]
@@ -3369,13 +3369,13 @@ class TestOverlappingPEReads:
 
         # POS           123456789012345678901234567890
         # read1[0]          AACGAAAAGGAGAA
-        # read2[0]                      TTTTAAATTTTTTT
-        # SNP                           ^^
+        # read2[0]                      AAAAAAATTTAAAA
+        # SNPs                          ^^
         genome_seq =  ["AAAAAACGAAAAGGAGAAAAAAATTTAAAA\n"
                        "TTTATTTTTTATTTTTTTGTGTTGTTTCTT"]
         # read1[1]      TTTATTTTTTATTT
-        # read2[1]                 ACAACACAAAAAAA
-        # SNP                      ^^
+        # read2[1]                 TTTTTTTGTGTTGT
+        # SNPs                     ^^
         # POS           123456789012345678901234567890
 
         snp_list = [['test_chrom', 17, "A", "T"],
@@ -3404,13 +3404,13 @@ class TestOverlappingPEReads:
         #
         with gzip.open(test_data.fastq1_remap_filename, "rt") as f:
             seqs1 = [x.strip() for x in f.readlines()][1::4]
-            # there are two pairs of reads and two snps (each with two alleles),
+            # there are two pairs of reads and two snps (each with two alleles)
             # leading to 2^2 combinations of alleles. however, one of those
             # combinations is the original pair (hence why we subtract by one)
             assert(len(set(seqs1)) == 2*(2**2-1))
         with gzip.open(test_data.fastq2_remap_filename, "rt") as f:
             seqs2 = [x.strip() for x in f.readlines()][1::4]
-            # there are two pairs of reads and two snps (each with two alleles),
+            # there are two pairs of reads and two snps (each with two alleles)
             # leading to 2^2 combinations of alleles. however, one of those
             # combinations is the original pair (hence why we subtract by one)
             assert(len(set(seqs2)) == 2*(2**2-1))
@@ -3419,33 +3419,45 @@ class TestOverlappingPEReads:
         expect_reads1 = [
             # only last base of first read should be changed from A to C
             "AACGAAAAGGAGAC",
-            # only second to last base of first read should be changed from A to T
+            # only second to last base of first read should be changed from A
+            # to T
             "AACGAAAAGGAGTA",
             # last base of first read should be changed from A to C
-            # AND second to last base of first read should be changed from A to T
+            # AND second to last base of first read should be changed from A
+            # to T
             "AACGAAAAGGAGTC",
             # second to last base of second read should be changed from T to G
             "TTTATTTTTTATGT",
-            # only third to last base of second read should be changed from T to A
+            # only third to last base of second read should be changed from T
+            # to A
             "TTTATTTTTTAATT",
             # second to last base of second read should be changed from T to G
-            # AND third to last base of second read should be changed from T to A
+            # AND third to last base of second read should be changed from T
+            # to A
             "TTTATTTTTTAAGT"
         ]
         expect_reads2 = [
-            # only second to last base of first read should be changed from T to G
+            # only second to last base of first read should be changed from T
+            # to G (since it is the complement of C)
             "TTTTAAATTTTTGT",
-            # only last base of first read should be changed from T to A
+            # only last base of first read should be changed from T to A (since
+            # it is the complement of T)
             "TTTTAAATTTTTTA",
-            # last base of first read should be changed from T to A
-            # AND second to last base of first read should be changed from T to G
+            # last base of first read should be changed from T to A (since it
+            # is the complement of T)
+            # AND second to last base of first read should be changed from T
+            # to G (since it is the complement of C)
             "TTTTAAATTTTTGA",
             # second to last base of second read should be changed from A to C
+            # (since it is the complement of G)
             "ACAACACAAAAACA",
-            # last base of second read should be changed from A to T
+            # last base of second read should be changed from A to T (since it
+            # is the complement of C)
             "ACAACACAAAAAAT",
-            # last base of second read should be changed from A to T
-            # AND second to last base of second read should be changed from A to C
+            # last base of second read should be changed from A to T (since it
+            # is the complement of A)
+            # AND second to last base of second read should be changed from A
+            # to C (since it is the complement of G)
             "ACAACACAAAAACT"
         ]
         expect_pairs = list(zip(expect_reads1, expect_reads2))
@@ -3479,15 +3491,15 @@ class TestOverlappingPEReads:
         test_data = Data()
 
         read1_seqs = ["AACGAAAAGGAGAA"]
-        read2_seqs = ["TTTTAAATTTTTTT"]
+        read2_seqs = ["TTTTAAATTTTTTT"]  # AAAAAAATTTAAAA
 
         read1_quals = ["B" * len(read1_seqs[0])]
         read2_quals = ["D" * len(read2_seqs[0])]
 
         # POS           123456789012345678901234567890
         # read1[0]          AACGAAAAGGAGAA
-        # read2[0]                      TTTTAAATTTTTTT
-        # SNP                    ^       ^^
+        # read2[0]                      AAAAAAATTTAAAA
+        # SNPs                   ^       ^^
         genome_seq =  ["AAAAAACGAAAAGGAGAAAAAAATTTAAAA\n"
                        "TTTATTTTTTATTTTTTTGTGTTGTTTCTT"]
 


### PR DESCRIPTION
resolves #2 and resolves #5 and resolves #8

When both reads from a read pair overlap a single variant, the reads that are generated for remapping should not be independent (i.e. if read1 has alternate allele, so should read2). In other words, generated reads should only be paired with each other if they have the same alleles at shared SNPs. `find_intersecting_snps.py` was altered to support this behavior.
A new function, `read_pair_combos()` computes all unique combinations of generated read pairs among reads that have the same alleles at shared SNPs. It uses another new function, `group_reads_by_snps()` to group a set of reads by whether they have the same alleles at shared SNPs.

Tests were written to ensure correct behavior.
1. `test_overlap_paired_two_reads_one_snp()` tests two pairs of reads, each with both pairs sharing a single SNP
2. `test_overlap_paired_two_reads_two_snps()` is similar but has both pairs overlapping two SNPs instead of one
2. `test_overlap_paired_one_read_one_snp_one_snp()` tests a single paired read, where both pairs share a SNP and overlap one other unshared SNP
3. `test_overlap_paired_one_read_one_discordant_snp()` tests a single paired read, where both pairs share a single SNP but have different alleles at that SNP. Reads should be discarded in this case.

Also, `generate_reads()` was rewritten to avoid recursion. Although less elegant, this likely helps it use less memory.