### PR TITLE
haplotype phase

### DIFF
--- a/mapping/find_intersecting_snps.py
+++ b/mapping/find_intersecting_snps.py
@@ -562,15 +562,13 @@ def generate_reads(read_seq, read_pos, ref_alleles, alt_alleles):
     of alleles (i.e. 2^n combinations where n is the number of snps overlapping
     the reads)
     """
-    # use a deque so that we can use the same object in memory after
-    # the nested for loop (rather than recreating a new list every time)
-    reads = deque([read_seq])
+    reads = [read_seq]
     # iterate through all snp locations
     for i in range(len(read_pos)):
         idx = read_pos[i]-1
         # for each read we've already created...
         for j in range(len(reads)):
-            read = reads.popleft()
+            read = reads[j]
             # create a new version of this read with both reference
             # and alternative versions of the allele at this index
             reads.append(
@@ -799,14 +797,12 @@ def read_pair_combos(old_reads, new_reads, max_seqs, snp_idx, snp_read_pos):
         unique_pairs - a set of tuples, each representing a unique pair of
                        new_reads
     """
-    # get the indices of the SNPs that are in both reads
-    shared_snp_idxs = set(snp_idx[0]).intersection(snp_idx[1])
     # get the indices of the shared SNPs in old_reads
     for i in range(len(snp_read_pos)):
-        # first, get the index of each snp_index in snp_idx
-        idx_idx = np.array([snp_idx[i].index(idx) for idx in shared_snp_idxs], dtype=int)
-        # now, use the indices in idx_idx to get the indices of the
-        # shared SNPs in the actual reads. note that we subtract by 1 to
+        # get the indices of the SNP indices that are in both reads
+        idx_idxs = np.nonzero(np.in1d(snp_idx[i], snp_idx[(i+1) % 2]))[0]
+        # now, use the indices in idx_idxs to get the relevant snp positions
+        snp_read_pos[i] = np.array(snp_read_pos[i], dtype=int)[idx_idxs]
         # convert positions to indices
         snp_read_pos[i] = np.array(snp_read_pos[i], dtype=int)[idx_idx] - 1
     # check: are there discordant alleles at the shared SNPs?

--- a/mapping/find_intersecting_snps.py
+++ b/mapping/find_intersecting_snps.py
@@ -802,9 +802,8 @@ def read_pair_combos(old_reads, new_reads, max_seqs, snp_idx, snp_read_pos):
         # get the indices of the SNP indices that are in both reads
         idx_idxs = np.nonzero(np.in1d(snp_idx[i], snp_idx[(i+1) % 2]))[0]
         # now, use the indices in idx_idxs to get the relevant snp positions
-        snp_read_pos[i] = np.array(snp_read_pos[i], dtype=int)[idx_idxs]
-        # convert positions to indices
-        snp_read_pos[i] = np.array(snp_read_pos[i], dtype=int)[idx_idx] - 1
+        # and convert positions to indices
+        snp_read_pos[i] = np.array(snp_read_pos[i], dtype=int)[idx_idxs] - 1
     # check: are there discordant alleles at the shared SNPs?
     # if so, discard these reads
     if (

--- a/mapping/find_intersecting_snps.py
+++ b/mapping/find_intersecting_snps.py
@@ -4,7 +4,6 @@ import gzip
 import argparse
 import numpy as np
 from itertools import product, groupby
-from collections import deque, defaultdict
 
 import pysam
 

--- a/mapping/find_intersecting_snps.py
+++ b/mapping/find_intersecting_snps.py
@@ -430,6 +430,7 @@ def count_ref_alt_matches(read, read_stats, snp_tab, snp_idx, read_pos):
 def get_unique_haplotypes(haplotypes, phasing, snp_idx):
     """
     returns list of vectors of unique haplotypes for this set of SNPs
+    all possible combinations of ref/alt are calculated at unphased sites
     """
     haps = haplotypes[snp_idx,:].T
     
@@ -439,7 +440,7 @@ def get_unique_haplotypes(haplotypes, phasing, snp_idx):
         phasing = np.logical_not(phasing[snp_idx, :].T.astype(bool))
     else:
         # assume all SNPs are unphased
-        phasing = np.full((haps.shape[0]/2, haps.shape[1]), True)
+        phasing = np.full((int(haps.shape[0]/2), haps.shape[1]), True)
 
     # if a haplotype has unphased SNPs, generate all possible allelic
     # combinations and add each combination as a new haplotype
@@ -472,7 +473,7 @@ def get_unique_haplotypes(haplotypes, phasing, snp_idx):
     h = np.ascontiguousarray(haps).view(np.dtype((np.void, haps.dtype.itemsize * haps.shape[1])))
 
     # get index of unique columns
-    _, idx, inverse_idx = np.unique(h, return_index=True, return_inverse=True)
+    _, idx = np.unique(h, return_index=True)
 
 
     return haps[idx,:]

--- a/mapping/snptable.py
+++ b/mapping/snptable.py
@@ -39,6 +39,7 @@ class SNPTable(object):
         self.snp_allele1 = np.array([], dtype="|S10")
         self.snp_allele2 = np.array([], dtype="|S10")
         self.haplotypes = None
+        self.phase = None
         self.n_snp = 0
         self.samples = []
         
@@ -49,6 +50,7 @@ class SNPTable(object):
         """read in SNPs and indels from HDF5 input files"""
 
         node_name = "/%s" % chrom_name
+        phase_node_name = "/phase_%s" % chrom_name
         
         if node_name not in snp_tab_h5:
             sys.stderr.write("WARNING: chromosome %s is not "
@@ -70,6 +72,8 @@ class SNPTable(object):
             self.n_snp = self.snp_pos.shape[0]
             self.samples = self.get_h5_samples(hap_h5, chrom_name)
             self.haplotypes = hap_h5.get_node(node_name)
+            if phase_node_name in hap_h5:
+                self.phase = hap_h5.get_node(phase_node_name)
             
             if samples:
                 # reduce set of SNPs and indels to ones that are
@@ -91,6 +95,8 @@ class SNPTable(object):
                 hap_idx[0::2] = samp_idx*2
                 hap_idx[1::2] = samp_idx*2 + 1
                 haps = self.haplotypes[:, hap_idx]
+                if self.phase:
+                    phase = self.phase[:, samp_idx]
 
                 # count number of ref and non-ref alleles,
                 # ignoring undefined (-1s)
@@ -113,6 +119,8 @@ class SNPTable(object):
                 self.samples = [x[0] for x in sorted_samps]
                 
                 self.haplotypes = haps[is_polymorphic,]
+                if self.phase:
+                    self.phase = phase[is_polymorphic,]
                 self.snp_pos = self.snp_pos[is_polymorphic]
                 self.snp_allele1 = self.snp_allele1[is_polymorphic]
                 self.snp_allele2 = self.snp_allele2[is_polymorphic]

--- a/snp2h5/Makefile
+++ b/snp2h5/Makefile
@@ -24,4 +24,4 @@ fasta2h5: fasta2h5.o $(objects)
 all: snp2h5 fasta2h5 $(objects)
 
 clean:
-	rm -f $(objects) snp2h5 fasta2h5
+	rm -f $(objects) snp2h5.o fasta2h5.o snp2h5 fasta2h5

--- a/snp2h5/snp2h5.c
+++ b/snp2h5/snp2h5.c
@@ -1055,6 +1055,7 @@ void parse_vcf(Arguments *args, Chromosome *all_chroms, int n_chrom,
   long i, j;
   float *geno_probs;
   char *haplotypes;
+  char *haplotypes_phase;
   long *snp_index;
   SNP snp;
   hsize_t row;
@@ -1062,6 +1063,10 @@ void parse_vcf(Arguments *args, Chromosome *all_chroms, int n_chrom,
   Chromosome *chrom;
   SampleTab *samp_tab;
   char **vcf_by_chrom;
+
+  /* create matrix to hold phase info */
+  H5MatrixInfo haplotype_phase_info;
+  haplotype_phase_info.h5file = haplotype_info->h5file;
   
   vcf = vcf_info_new();
 
@@ -1137,6 +1142,12 @@ void parse_vcf(Arguments *args, Chromosome *all_chroms, int n_chrom,
 	samp_tab = sample_tab_from_names(haplotype_info->h5file, chrom->name,
 					 vcf->sample_names, vcf->n_sample);
 	sample_tab_free(samp_tab);
+
+  /* initialize the phase matrix */
+  haplotypes_phase = my_malloc(vcf->n_sample * sizeof(char));
+  init_h5matrix(&haplotype_phase_info, haplotype_info->n_row,
+          vcf->n_sample,
+          HAPLOTYPE_DATATYPE, util_str_concat("phase_", chrom->name, NULL));
       }
     } else {
       haplotypes = NULL;
@@ -1168,13 +1179,14 @@ void parse_vcf(Arguments *args, Chromosome *all_chroms, int n_chrom,
     int done = FALSE;
     
     while(!done && vcf_read_line(gzf, vcf, &snp,
-				 geno_probs, haplotypes) != -1) {
+				 geno_probs, haplotypes, haplotypes_phase) != -1) {
       
       if(geno_probs) {
 	write_h5matrix_row(gprob_info, row, geno_probs);
       }
       if(haplotypes) {
 	write_h5matrix_row(haplotype_info, row, haplotypes);
+  write_h5matrix_row(&haplotype_phase_info, row, haplotypes_phase);
       }
 
       /*  set snp_index element at this chromosome position
@@ -1226,6 +1238,10 @@ void parse_vcf(Arguments *args, Chromosome *all_chroms, int n_chrom,
     if(haplotypes) {
       my_free(haplotypes);
       close_h5matrix(haplotype_info);
+    }
+    if(haplotypes_phase) {
+      my_free(haplotypes_phase);
+      close_h5matrix(&haplotype_phase_info);
     }
     if(snp_index) {
       my_free(snp_index);

--- a/snp2h5/vcf.h
+++ b/snp2h5/vcf.h
@@ -51,7 +51,7 @@ void vcf_read_header(gzFile vcf_fh, VCFInfo *vcf_info);
 
 int vcf_read_line(gzFile vcf_fh, VCFInfo *vcf_info, SNP *snp,
 		  float *geno_probs,
-		  char *haplotypes);
+		  char *haplotypes, char *haplotypes_phase);
 
 
 #endif


### PR DESCRIPTION
resolves #3

`snp2h5` doesn't consider haplotype phase when generating `haplotypes.h5`. However, `find_intersecting_snps.py` assumes all haplotypes are phased when it uses `haplotype.h5`, since phase information is required to know which alleles are reference/alternate.

`snp2h5` was altered to add a new phase `carray` to `haplotype.h5` containing phase information from the VCF. The structure of the `carray` is similar to that of the haplotypes themselves: there is a row for each SNP and a column for each individual. A value of 0 indicates an unphased genotype and a value of 1 indicates the genotype is phased.

`find_intersecting_snps.py` will now use the phase information from `haplotype.h5` to calculate new haplotypes with all possible allelic combinations at unphased sites, resulting in more reads being generated for remapping. If phase information is not provided in `haplotype.h5`, all sites will be assumed unphased.

The new behavior of `snp2h5` was verified manually, and a single test was written to ensure new code in `find_intersecting_snps.py` worked correctly. `test_haplotypes_phase_single_one_read_two_snps()` tests that marking a certain genotype as unphased causes another read to be generated containing a new haplotype configuration.